### PR TITLE
Add FastAPI endpoint tests

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_chat_echo():
+    message = {"message": "Hello"}
+    response = client.post("/chat", json=message)
+    assert response.status_code == 200
+    assert response.json() == message


### PR DESCRIPTION
## Summary
- add tests for /health and /chat endpoints using FastAPI TestClient

## Testing
- `pytest backend/tests/test_main.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68ab702ab560832d8e16d3a3d8e0d777