### PR TITLE
Implement async health_check and chat

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+import asyncio
+from typing import Dict
+
+
+async def generate_response(message: str) -> str:
+    """Mock async function to generate a response."""
+    await asyncio.sleep(0)
+    return message[::-1]
+
+
+async def health_check() -> Dict[str, str]:
+    """Return the application's health status."""
+    return {"status": "ok"}
+
+
+async def chat(message: str) -> Dict[str, str]:
+    """Handle chat messages asynchronously."""
+    response = await generate_response(message)
+    return {"response": response}


### PR DESCRIPTION
## Summary
- Add `backend/app/main.py` with asynchronous `health_check` and `chat` endpoints
- Include mock `generate_response` to demonstrate awaited downstream call

## Testing
- `python -m py_compile backend/app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab702456e8832d95ea160563334d15