### PR TITLE
Add goal and task models with CRUD API and frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,107 @@
+from fastapi import FastAPI, HTTPException
+from typing import List, Optional
+from sqlmodel import Session, select
+
+from .database import create_db_and_tables, engine
+from .models import Goal, Task
+
+app = FastAPI()
+
+@app.on_event("startup")
+def on_startup():
+    create_db_and_tables()
+
+# Goal endpoints
+@app.post('/goals', response_model=Goal)
+def create_goal(goal: Goal):
+    with Session(engine) as session:
+        session.add(goal)
+        session.commit()
+        session.refresh(goal)
+        return goal
+
+@app.get('/goals', response_model=List[Goal])
+def read_goals():
+    with Session(engine) as session:
+        goals = session.exec(select(Goal)).all()
+        return goals
+
+@app.get('/goals/{goal_id}', response_model=Goal)
+def read_goal(goal_id: int):
+    with Session(engine) as session:
+        goal = session.get(Goal, goal_id)
+        if not goal:
+            raise HTTPException(status_code=404, detail='Goal not found')
+        return goal
+
+@app.put('/goals/{goal_id}', response_model=Goal)
+def update_goal(goal_id: int, data: Goal):
+    with Session(engine) as session:
+        goal = session.get(Goal, goal_id)
+        if not goal:
+            raise HTTPException(status_code=404, detail='Goal not found')
+        for key, value in data.dict(exclude_unset=True).items():
+            setattr(goal, key, value)
+        session.add(goal)
+        session.commit()
+        session.refresh(goal)
+        return goal
+
+@app.delete('/goals/{goal_id}')
+def delete_goal(goal_id: int):
+    with Session(engine) as session:
+        goal = session.get(Goal, goal_id)
+        if not goal:
+            raise HTTPException(status_code=404, detail='Goal not found')
+        session.delete(goal)
+        session.commit()
+        return {'ok': True}
+
+# Task endpoints
+@app.post('/tasks', response_model=Task)
+def create_task(task: Task):
+    with Session(engine) as session:
+        session.add(task)
+        session.commit()
+        session.refresh(task)
+        return task
+
+@app.get('/tasks', response_model=List[Task])
+def read_tasks(goal_id: Optional[int] = None):
+    with Session(engine) as session:
+        statement = select(Task)
+        if goal_id is not None:
+            statement = statement.where(Task.goal_id == goal_id)
+        tasks = session.exec(statement).all()
+        return tasks
+
+@app.get('/tasks/{task_id}', response_model=Task)
+def read_task(task_id: int):
+    with Session(engine) as session:
+        task = session.get(Task, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail='Task not found')
+        return task
+
+@app.put('/tasks/{task_id}', response_model=Task)
+def update_task(task_id: int, data: Task):
+    with Session(engine) as session:
+        task = session.get(Task, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail='Task not found')
+        for key, value in data.dict(exclude_unset=True).items():
+            setattr(task, key, value)
+        session.add(task)
+        session.commit()
+        session.refresh(task)
+        return task
+
+@app.delete('/tasks/{task_id}')
+def delete_task(task_id: int):
+    with Session(engine) as session:
+        task = session.get(Task, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail='Task not found')
+        session.delete(task)
+        session.commit()
+        return {'ok': True}

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,9 @@
+from sqlmodel import SQLModel, create_engine
+
+sqlite_file_name = 'database.db'
+sqlite_url = f'sqlite:///{sqlite_file_name}'
+
+engine = create_engine(sqlite_url, echo=True)
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,18 @@
+from typing import Optional, List
+from sqlmodel import SQLModel, Field, Relationship
+
+class Goal(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    target_date: Optional[str] = None
+
+    tasks: List['Task'] = Relationship(back_populates='goal')
+
+class Task(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    description: str
+    completed: bool = False
+    goal_id: int = Field(foreign_key='goal.id')
+
+    goal: Optional[Goal] = Relationship(back_populates='tasks')

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,132 @@
+const { useState, useEffect } = React;
+
+function GoalForm({ onAdd }) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/goals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description })
+    });
+    const newGoal = await res.json();
+    onAdd(newGoal);
+    setTitle('');
+    setDescription('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Goal title" />
+      <input value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
+      <button type="submit">Add Goal</button>
+    </form>
+  );
+}
+
+function TaskList({ goal, onChange }) {
+  const [tasks, setTasks] = useState([]);
+  const [desc, setDesc] = useState('');
+
+  useEffect(() => {
+    if (goal) {
+      fetch(`/tasks?goal_id=${goal.id}`).then(res => res.json()).then(setTasks);
+    }
+  }, [goal]);
+
+  const addTask = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: desc, goal_id: goal.id })
+    });
+    const newTask = await res.json();
+    const updated = [...tasks, newTask];
+    setTasks(updated);
+    setDesc('');
+    onChange();
+  };
+
+  const toggleComplete = async (task) => {
+    const res = await fetch(`/tasks/${task.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completed: !task.completed })
+    });
+    const updated = await res.json();
+    setTasks(tasks.map(t => t.id === updated.id ? updated : t));
+    onChange();
+  };
+
+  return (
+    <div>
+      <h3>Tasks for {goal.title}</h3>
+      <ul>
+        {tasks.map(t => (
+          <li key={t.id}>
+            <input type="checkbox" checked={t.completed} onChange={() => toggleComplete(t)} />
+            {t.description}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={addTask}>
+        <input value={desc} onChange={e => setDesc(e.target.value)} placeholder="New task" />
+        <button type="submit">Add Task</button>
+      </form>
+    </div>
+  );
+}
+
+function AchievementSummary({ refresh }) {
+  const [summary, setSummary] = useState({ total: 0, completed: 0 });
+
+  useEffect(() => {
+    fetch('/tasks').then(res => res.json()).then(tasks => {
+      const total = tasks.length;
+      const completed = tasks.filter(t => t.completed).length;
+      setSummary({ total, completed });
+    });
+  }, [refresh]);
+
+  return (
+    <div>
+      <h2>Achievements</h2>
+      <p>{summary.completed} of {summary.total} tasks completed</p>
+    </div>
+  );
+}
+
+function GoalApp() {
+  const [goals, setGoals] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [refresh, setRefresh] = useState(0);
+
+  useEffect(() => {
+    fetch('/goals').then(res => res.json()).then(setGoals);
+  }, []);
+
+  const addGoal = (goal) => {
+    setGoals([...goals, goal]);
+  };
+
+  const refreshSummary = () => setRefresh(r => r + 1);
+
+  return (
+    <div>
+      <h1>Lifecoach Goals</h1>
+      <GoalForm onAdd={addGoal} />
+      <ul>
+        {goals.map(g => (
+          <li key={g.id} onClick={() => setSelected(g)}>{g.title}</li>
+        ))}
+      </ul>
+      {selected && <TaskList goal={selected} onChange={refreshSummary} />}
+      <AchievementSummary refresh={refresh} />
+    </div>
+  );
+}
+
+ReactDOM.render(<GoalApp />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Lifecoach</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+sqlmodel
+uvicorn


### PR DESCRIPTION
## Summary
- add SQLModel Goal and Task models with relationship
- implement FastAPI CRUD endpoints for goals and tasks
- create React components for goal creation, task management, and achievement summary

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab61b175b4832d9e1cdf8bc611c67e